### PR TITLE
Add custom domain configuration to GitHub Actions workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -48,6 +48,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Create CNAME file
+        run: echo "subasi.is-a.dev" > public/CNAME
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules


### PR DESCRIPTION
This PR adds a step to our GitHub Actions workflow to create a CNAME file for the custom domain subasi.is-a.dev. Closes #8.